### PR TITLE
Api syntax fixes, adding of MOMDPDiscreteUpdater

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MOMDPs"
 uuid = "77fc6e33-3f81-4304-8123-5a68e6b3eeb4"
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ page_order = [
     "MOMDPs.jl" => "index.md",
     "Defining a MOMDP" => "defining_momdp.md",
     "Policies" => "policies.md",
+    "Belief Updaters" => "belief_updaters.md",
     "Discrete Helper Functions" => "discrete_momdp_functions.md",
     "Examples" => "examples.md",
     "API" => "api.md"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, POMDPs, MOMDPs
+using Documenter, POMDPs, POMDPTools, MOMDPs
 
 page_order = [
     "MOMDPs.jl" => "index.md",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -48,6 +48,7 @@ POMDPTools.Policies.action(p::MOMDPAlphaVectorPolicy, b)
 POMDPTools.Policies.action(p::MOMDPAlphaVectorPolicy, b, x)
 POMDPTools.Policies.actionvalues(p::MOMDPAlphaVectorPolicy, b, x)
 POMDPTools.BeliefUpdaters.initialize_belief(bu::MOMDPDiscreteUpdater, dist::Any)
+POMDPTools.BeliefUpdaters.update(bu::MOMDPDiscreteUpdater, b::DiscreteBelief, a, o, x, xp)
 POMDPTools.BeliefUpdaters.update(bu::MOMDPDiscreteUpdater, b::Any, a, o, x, xp)
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -6,6 +6,7 @@
 MOMDPs.MOMDP
 MOMDPs.POMDP_of_Discrete_MOMDP
 MOMDPs.MOMDPAlphaVectorPolicy
+MOMDPs.MOMDPDiscreteUpdater
 ```
 
 ## Exported Functions
@@ -26,6 +27,8 @@ MOMDPs.ordered_states_y
 MOMDPs.is_y_prime_dependent_on_x_prime
 MOMDPs.is_x_prime_dependent_on_y
 MOMDPs.is_initial_distribution_independent
+MOMDPs.beliefvec_y
+MOMDPs.uniform_belief_y
 ```
 
 ## Extended Functions
@@ -39,8 +42,17 @@ POMDPs.initialstate(p::MOMDP{X,Y,A,O}) where {X,Y,A,O}
 POMDPs.observations(p::POMDP_of_Discrete_MOMDP)
 POMDPs.observation(p::POMDP_of_Discrete_MOMDP{X, Y, A, O}, a::A, s::Tuple{X,Y}) where {X,Y,A,O}
 POMDPs.obsindex(p::POMDP_of_Discrete_MOMDP, o)
-MOMDPs.value
-MOMDPs.action
+POMDPTools.Policies.value(p::MOMDPAlphaVectorPolicy, b)
+POMDPTools.Policies.value(p::MOMDPAlphaVectorPolicy, b, x)
+POMDPTools.Policies.action(p::MOMDPAlphaVectorPolicy, b)
+POMDPTools.Policies.action(p::MOMDPAlphaVectorPolicy, b, x)
+POMDPTools.Policies.actionvalues(p::MOMDPAlphaVectorPolicy, b, x)
+POMDPTools.BeliefUpdaters.initialize_belief(bu::MOMDPDiscreteUpdater, dist::Any)
+POMDPTools.BeliefUpdaters.update(bu::MOMDPDiscreteUpdater, b::Any, a, o, x, xp)
+```
+
+## Internal Functions
+```@docs
 MOMDPs.alphapairs
 MOMDPs.alphavectors
 ```

--- a/docs/src/belief_updaters.md
+++ b/docs/src/belief_updaters.md
@@ -1,0 +1,19 @@
+# Belief Updaters
+
+The only updater currently implemented is the [`MOMDPDiscreteUpdater`](@ref).
+
+## `MOMDPDiscreteUpdater`
+
+The [`MOMDPDiscreteUpdater`](@ref) is a discrete belief updater for MOMDPs. The [`update`](@ref) function implements the discrete Bayesian filter for MOMDPs, which updates beliefs over hidden states given knowledge of visible state transitions. The `update` function requires the current belief `b`, the action taken `a`, the observation received `o`, the visible state from which the action was taken `x`, and the visible state that we transitioned to `xp`.
+
+### Example Usage
+```julia
+momdp = YourMOMDPProblem()
+updater = MOMDPDiscreteUpdater(momdp)
+
+# Initialize belief over hidden states
+initial_dist = initialstate_y(momdp)
+
+# Update belief after taking action and receiving observation
+new_belief = update(updater, current_belief, action_taken, observation_received, x, xp)
+```

--- a/docs/src/belief_updaters.md
+++ b/docs/src/belief_updaters.md
@@ -1,10 +1,10 @@
 # Belief Updaters
 
-The only updater currently implemented is the [`MOMDPDiscreteUpdater`](@ref).
+The only updater currently implemented is the [`MOMDPs.MOMDPDiscreteUpdater`](@ref).
 
 ## `MOMDPDiscreteUpdater`
 
-The [`MOMDPDiscreteUpdater`](@ref) is a discrete belief updater for MOMDPs. The [`update`](@ref) function implements the discrete Bayesian filter for MOMDPs, which updates beliefs over hidden states given knowledge of visible state transitions. The `update` function requires the current belief `b`, the action taken `a`, the observation received `o`, the visible state from which the action was taken `x`, and the visible state that we transitioned to `xp`.
+The [`MOMDPs.MOMDPDiscreteUpdater`](@ref) is a discrete belief updater for MOMDPs. The [`update`](@ref) function implements the discrete Bayesian filter for MOMDPs, which updates beliefs over hidden states given knowledge of visible state transitions. The `update` function requires the current belief `b`, the action taken `a`, the observation received `o`, the visible state from which the action was taken `x`, and the visible state that we transitioned to `xp`.
 
 ### Example Usage
 ```julia

--- a/docs/src/policies.md
+++ b/docs/src/policies.md
@@ -20,7 +20,11 @@ However, to maintain compatibility with simulation tools already existing within
 $$V^\prime(b) = \sum_{x \in \mathcal{X}} b_{\mathcal{X}}(x) V(x, b_{\mathcal{Y} \mid x})$$
 where $b_{\mathcal{Y} \mid x} = b(x,y) / b_{\mathcal{X}}(x)$. This value calcualtion is provided by [`value(p::MOMDPAlphaVectorPolicy, b)`](@ref).
 
+When the visible state is known, we also provide [`actionvalues(p::MOMDPAlphaVectorPolicy, b, x)`](@ref) to compute the action values (Q-values) for all actions given a belief `b` over hidden states and a known visible state `x`. This performes a one-step lookahead to compute action values.
+
 ## Action Function
 The action function [`action(p::MOMDPAlphaVectorPolicy, b)`](@ref) implements a heuristic instead of a true one step lookahead when there is uncertainty over $\mathcal{X}$. If executing the MOMDP policy as a POMDP and `x` is not known, then we recommend implementing a custom action function that performs a one-step lookahead using the `value` function. 
 
 As implemented, `action` finds the state `x` with the largest probability mass in `b`, forms a conditional distribution over `y` given that `x`, finds the alpha vector within the subset associated with `x` that maximizes the value given the conditional distirbution, and returns the actions associated with that alpha vector.
+
+We also provide a function [`action(p::MOMDPAlphaVectorPolicy, b, x)`](@ref) that assumes the visible state `x` is known and avoides the need to infer `x` from the belief distribution.

--- a/src/MOMDPs.jl
+++ b/src/MOMDPs.jl
@@ -38,12 +38,17 @@ export
     
     POMDP_of_Discrete_MOMDP,
     
-    MOMDPAlphaVectorPolicy
+    MOMDPAlphaVectorPolicy,
+    beliefvec_y,
+    MOMDPDiscreteUpdater,
+    uniform_belief_y
+    
     
 
 include("momdp.jl")
 include("discrete_momdp_functions.jl")
 include("pomdp_of_momdp.jl")
 include("alpha_vector.jl")
+include("updater.jl")
 
 end # module

--- a/src/alpha_vector.jl
+++ b/src/alpha_vector.jl
@@ -303,11 +303,11 @@ function POMDPTools.Policies.actionvalues(p::MOMDPAlphaVectorPolicy, b, x)
     qa = zeros(na)
     up = MOMDPDiscreteUpdater(p.momdp)
     for ai in 1:na
-        for (yi, yprob) in weighted_iterator(b)
+        for (yi, yprob) in weighted_iterator_y(b)
             rew_sum = reward(p.momdp, (x, yi), ai)
             for (xpi, xpprob) in weighted_iterator(transition_x(p.momdp, (x, yi), ai))
                 xpprob == 0.0 && continue
-                for (ypi, ypprob) in weighted_iterator(transition_y(p.momdp, (x, yi), ai, xpi))
+                for (ypi, ypprob) in weighted_iterator_y(transition_y(p.momdp, (x, yi), ai, xpi))
                     ypprob == 0.0 && continue
                     for (oi, oprob) in weighted_iterator(observation(p.momdp, ai, (xpi, ypi)))
                         oprob == 0.0 && continue
@@ -370,3 +370,5 @@ function beliefvec_y(m::MOMDP, n_states_y, b::Deterministic)
     b′[y_idx] = 1.0
     return b′
 end
+
+weighted_iterator_y(d) = (x=>pdf_y(d, x) for x in support(d))

--- a/src/discrete_momdp_functions.jl
+++ b/src/discrete_momdp_functions.jl
@@ -30,11 +30,7 @@ Helper function to return the full transition distribution for discrete MOMDPs. 
     are Tuple{X,Y}. It uses `transition_x` and `transition_y` to construct the
     distribution.
 """
-function POMDPs.transition(p::MOMDP{X,Y,A,O}, s::Tuple{X,Y}, a::A) where {X,Y,A,O}
-    if isterminal(p, s)
-        return SparseCat([s], [1.0])
-    end
-    
+function POMDPs.transition(p::MOMDP{X,Y,A,O}, s::Tuple{X,Y}, a::A) where {X,Y,A,O}    
     x_dist = transition_x(p, s, a)
     
     # Use dictionary to accumulate weights

--- a/src/updater.jl
+++ b/src/updater.jl
@@ -167,17 +167,7 @@ Update a discrete belief over hidden states using the MOMDP belief update equati
 
 # Description
 This function implements the discrete Bayesian filter for MOMDPs, which updates beliefs
-over hidden states given knowledge of visible state transitions. The update equation is:
-
-```math
-b'(y') \\propto \\eta \\sum_y O(o | x, y, a, x', y') \\cdot T_y(y' | x, y, a, x') \\cdot b(y)
-```
-
-where:
-- `b'(y')` is the updated belief probability for hidden state `y'`
-- `O(o | x, y, a, x', y')` is the observation probability given states and action
-- `T_y(y' | x, y, a, x')` is the hidden state transition probability
-- `b(y)` is the current belief probability for hidden state `y`
+over hidden states given knowledge of visible state transitions.
 
 The function iterates through all current hidden states with non-zero probability,
 computes transition probabilities to next hidden states, weights by observation
@@ -230,20 +220,6 @@ end
 """
     update(bu::MOMDPDiscreteUpdater, b::Any, a, o, x, xp)
 
-Update a belief of any type by first converting it to a discrete belief, then updating.
-
-# Arguments
-- `bu::MOMDPDiscreteUpdater`: The MOMDP discrete belief updater
-- `b::Any`: The current belief (will be converted to discrete belief if needed)
-- `a`: The action taken
-- `o`: The observation received after taking action `a`
-- `x`: The previous visible state
-- `xp`: The current visible state
-
-# Returns
-- A new `DiscreteBelief` representing the updated belief over hidden states
-
-# Description
 This is a convenience method that handles arbitrary belief types by first calling
 `initialize_belief` to convert them to a `DiscreteBelief`, then performing the
 standard discrete belief update.

--- a/src/updater.jl
+++ b/src/updater.jl
@@ -1,0 +1,251 @@
+"""
+    MOMDPDiscreteUpdater
+
+An updater type for maintaining and updating discrete beliefs over hidden states in a Mixed Observability Markov Decision Process (MOMDP).
+
+# Constructor
+    MOMDPDiscreteUpdater(momdp::MOMDP)
+
+Create a discrete belief updater for the given MOMDP.
+
+# Fields
+- `momdp <: MOMDP`: The MOMDP problem instance for which beliefs will be updated
+
+# Description
+In a MOMDP, the state space is factored into visible states `x` (fully observable) and 
+hidden states `y` (partially observable). This updater maintains beliefs only over the 
+hidden states, since the visible states are assumed to be directly observed.
+
+The updater implements the discrete Bayesian filter for belief updates, assuming:
+- Finite, discrete hidden state spaces
+- Known visible state transitions (x → x')
+- Probabilistic hidden state transitions that may depend on visible states
+- Observations that depend on both visible and hidden states
+
+# Usage
+```julia
+momdp = YourMOMDPProblem()
+updater = MOMDPDiscreteUpdater(momdp)
+
+# Initialize belief over hidden states
+initial_dist = initialstate_y(momdp)
+
+# Update belief after taking action and receiving observation
+new_belief = update(updater, current_belief, action, observation, x, xp)
+```
+
+# See Also
+- `uniform_belief_y`: Create uniform beliefs over hidden states
+- `initialize_belief`: Initialize beliefs from distributions
+- `update`: Perform belief updates using the MOMDP filter
+"""
+mutable struct MOMDPDiscreteUpdater{P<:MOMDP} <: Updater
+    momdp::P
+end
+
+"""
+     uniform_belief_y(momdp)
+     uniform_belief_y(up::MOMDPDiscreteUpdater)
+
+Return a uniform DiscreteBelief over all hidden states in the MOMDP.
+
+# Arguments
+- `momdp`: A MOMDP problem instance, or
+- `up::MOMDPDiscreteUpdater`: A MOMDP discrete belief updater
+
+# Returns
+- A `DiscreteBelief` with equal probability `1/|Y|` for each hidden state `y ∈ Y`
+
+# Description
+This function creates a uniform prior belief over the hidden state space, which is often 
+used as an initial belief when the true hidden state is unknown. In MOMDP problems, this 
+represents maximum uncertainty about the hidden state while the visible state is assumed 
+to be known.
+
+The uniform belief is particularly useful for:
+- Initializing belief when no prior information is available
+- Baseline comparisons in experiments
+- Worst-case analysis of belief-dependent policies
+
+# Example
+```julia
+momdp = YourMOMDPProblem()
+initial_belief = uniform_belief_y(momdp)
+# or
+updater = MOMDPDiscreteUpdater(momdp)
+initial_belief = uniform_belief_y(updater)
+```
+"""
+function uniform_belief_y(momdp)
+    state_list = ordered_states_y(momdp)
+    ny = length(state_list)
+    return DiscreteBelief(momdp, state_list, ones(ny) / ny)
+end
+uniform_belief_y(up::MOMDPDiscreteUpdater) = uniform_belief_y(up.momdp)
+
+"""
+    initialize_belief(bu::MOMDPDiscreteUpdater, dist::Any)
+
+Initialize a discrete belief over hidden states from a given distribution.
+
+# Arguments
+- `bu::MOMDPDiscreteUpdater`: The MOMDP discrete belief updater
+- `dist`: A distribution over hidden states to initialize from (supports various distribution types)
+
+# Returns
+- A `DiscreteBelief` over the hidden state space with probabilities initialized from `dist`
+
+# Description
+This function creates a discrete belief representation over the hidden states `y` suitable 
+for use with MOMDP belief update operations. The conversion process:
+
+1. Creates a zero-initialized probability vector over all hidden states in the MOMDP
+2. For each state `y` in the support of the input distribution, extracts the probability 
+   `pdf(dist, y)` and assigns it to the corresponding index in the belief vector
+3. Returns a `DiscreteBelief` object that can be used with the MOMDP updater
+
+# Supported Distribution Types
+The function can handle various distribution types through the generic `pdf` interface:
+- Discrete distributions (e.g., `Categorical`, `DiscreteUniform`)
+- Custom distributions that implement `pdf` and `support`
+- Sparse distributions with limited support
+
+# Usage Examples
+```julia
+updater = MOMDPDiscreteUpdater(momdp)
+
+# From a uniform distribution
+uniform_dist = DiscreteUniform(1, length(states_y(momdp)))
+belief = initialize_belief(updater, uniform_dist)
+
+# From a sparse categorical distribution  
+sparse_dist = SparseCat([state1, state3], [0.7, 0.3])
+belief = initialize_belief(updater, sparse_dist)
+```
+
+# Implementation Notes
+- Uses `stateindex_y` to map hidden states to belief vector indices
+- Assumes the distribution is over individual hidden states, not joint (x,y) states
+- The resulting belief is properly normalized if the input distribution is normalized
+"""
+function POMDPTools.BeliefUpdaters.initialize_belief(bu::MOMDPDiscreteUpdater, dist::Any)
+    state_list = ordered_states_y(bu.momdp)
+    ns = length(state_list)
+    b = zeros(ns)
+    belief = DiscreteBelief(bu.momdp, state_list, b)
+    temp_x = first(states_x(bu.momdp))
+    for y in support(dist)
+        yidx = stateindex_y(bu.momdp, (temp_x, y))
+        belief.b[yidx] = pdf_y(dist, y)
+    end
+    return belief
+end
+
+pdf_y(dist::Any, y) = pdf(dist, y)
+pdf_y(b::DiscreteBelief, x, y) = b.b[stateindex_y(b.pomdp, (x, y))]
+function pdf_y(b::DiscreteBelief, y)
+    x_temp = first(states_x(b.pomdp))
+    return pdf_y(b, x_temp, y)
+end
+
+
+"""
+    update(bu::MOMDPDiscreteUpdater, b::DiscreteBelief, a, o, x, xp)
+
+Update a discrete belief over hidden states using the MOMDP belief update equation.
+
+# Arguments
+- `bu::MOMDPDiscreteUpdater`: The MOMDP discrete belief updater
+- `b::DiscreteBelief`: The current belief over hidden states `y`
+- `a`: The action taken
+- `o`: The observation received after taking action `a`
+- `x`: The previous visible state
+- `xp`: The current visible state
+
+# Returns
+- A new `DiscreteBelief` representing the updated belief over hidden states
+
+# Description
+This function implements the discrete Bayesian filter for MOMDPs, which updates beliefs
+over hidden states given knowledge of visible state transitions. The update equation is:
+
+```math
+b'(y') \\propto \\eta \\sum_y O(o | x, y, a, x', y') \\cdot T_y(y' | x, y, a, x') \\cdot b(y)
+```
+
+where:
+- `b'(y')` is the updated belief probability for hidden state `y'`
+- `O(o | x, y, a, x', y')` is the observation probability given states and action
+- `T_y(y' | x, y, a, x')` is the hidden state transition probability
+- `b(y)` is the current belief probability for hidden state `y`
+
+The function iterates through all current hidden states with non-zero probability,
+computes transition probabilities to next hidden states, weights by observation
+probabilities, and normalizes the result.
+
+# Errors
+Throws an error if the updated belief probabilities sum to zero, which indicates
+an impossible observation given the current belief and action.
+"""
+function POMDPTools.BeliefUpdaters.update(bu::MOMDPDiscreteUpdater, b::DiscreteBelief, a, o, x, xp)
+    momdp = bu.momdp
+    state_space_y = b.state_list
+    bp = zeros(length(state_space_y))
+
+    for (yi, y) in enumerate(state_space_y)
+        if b.b[yi] > 0.0
+            td = transition_y(momdp, (x, y), a, xp)
+
+            for (yp, tp) in weighted_iterator(td)
+                ypi = stateindex_y(momdp, (xp, yp))
+                op = obs_weight(momdp, (x, y), a, (xp, yp), o) # shortcut for observation probability from POMDPModelTools
+
+                bp[ypi] += op * tp * b.b[yi]
+            end
+        end
+    end
+
+    bp_sum = sum(bp)
+
+    if bp_sum == 0.0
+        error("""
+              Failed discrete belief update: new probabilities sum to zero.
+
+              b = $b
+              a = $a
+              o = $o
+              x = $x
+              xp = $xp
+
+              Failed discrete belief update: new probabilities sum to zero.
+              """)
+    end
+
+    # Normalize
+    bp ./= bp_sum
+
+    return DiscreteBelief(momdp, b.state_list, bp)
+end
+
+"""
+    update(bu::MOMDPDiscreteUpdater, b::Any, a, o, x, xp)
+
+Update a belief of any type by first converting it to a discrete belief, then updating.
+
+# Arguments
+- `bu::MOMDPDiscreteUpdater`: The MOMDP discrete belief updater
+- `b::Any`: The current belief (will be converted to discrete belief if needed)
+- `a`: The action taken
+- `o`: The observation received after taking action `a`
+- `x`: The previous visible state
+- `xp`: The current visible state
+
+# Returns
+- A new `DiscreteBelief` representing the updated belief over hidden states
+
+# Description
+This is a convenience method that handles arbitrary belief types by first calling
+`initialize_belief` to convert them to a `DiscreteBelief`, then performing the
+standard discrete belief update.
+"""
+POMDPTools.BeliefUpdaters.update(bu::MOMDPDiscreteUpdater, b::Any, a, o, x, xp) = update(bu, initialize_belief(bu, b), a, o, x, xp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -652,6 +652,171 @@ end
         end
     end
     
+    @testset "beliefvec_y Tests" begin
+        _, momdp, _ = create_test_rocksample()
+        n_y = length(states_y(momdp))
+        states_y_list = ordered_states_y(momdp)
+        
+        @testset "SparseCat Conversion" begin
+            # Test with sparse categorical distribution
+            sparse_states = [states_y_list[1], states_y_list[3]]
+            sparse_probs = [0.7, 0.3]
+            sparse_belief = SparseCat(sparse_states, sparse_probs)
+            
+            b_vec = MOMDPs.beliefvec_y(momdp, n_y, sparse_belief)
+            
+            @test length(b_vec) == n_y
+            @test b_vec[1] ≈ 0.7  # First state
+            @test b_vec[2] ≈ 0.0  # Not in sparse support
+            @test b_vec[3] ≈ 0.3  # Third state
+            @test sum(b_vec) ≈ 1.0
+            @test all(b_vec .≥ 0.0)
+        end
+        
+        @testset "AbstractVector Conversion" begin
+            # Test with vector input
+            input_vec = [0.2, 0.5, 0.1, 0.2, 0.0, 0.0, 0.0, 0.0]
+            @test length(input_vec) == n_y  # Ensure correct length
+            
+            b_vec = MOMDPs.beliefvec_y(momdp, n_y, input_vec)
+            
+            @test b_vec === input_vec  # Should return same vector
+            @test length(b_vec) == n_y
+            
+            # Test assertion for wrong length
+            wrong_length_vec = [0.5, 0.5]
+            @test_throws AssertionError MOMDPs.beliefvec_y(momdp, n_y, wrong_length_vec)
+        end
+        
+        @testset "DiscreteBelief Conversion" begin
+            # Test with DiscreteBelief
+            prob_vec = [0.1, 0.2, 0.3, 0.4, 0.0, 0.0, 0.0, 0.0]
+            discrete_belief = DiscreteBelief(momdp, states_y_list, prob_vec)
+            
+            b_vec = MOMDPs.beliefvec_y(momdp, n_y, discrete_belief)
+            
+            @test b_vec === discrete_belief.b  # Should return underlying vector
+            @test length(b_vec) == n_y
+            @test b_vec ≈ prob_vec
+        end
+        
+        @testset "Deterministic Conversion" begin
+            # Test with deterministic belief
+            det_state = states_y_list[2]  # Second hidden state
+            det_belief = Deterministic(det_state)
+            
+            b_vec = MOMDPs.beliefvec_y(momdp, n_y, det_belief)
+            
+            @test length(b_vec) == n_y
+            @test sum(b_vec) ≈ 1.0
+            @test count(x -> x > 0, b_vec) == 1  # Only one non-zero element
+            @test b_vec[2] ≈ 1.0  # Second state should have probability 1
+            @test all(b_vec[i] ≈ 0.0 for i in [1, 3, 4, 5, 6, 7, 8])  # Others zero
+        end
+        
+        @testset "Edge Cases" begin
+            # Test with uniform sparse belief
+            uniform_sparse = SparseCat(states_y_list, fill(1.0/n_y, n_y))
+            b_vec_uniform = MOMDPs.beliefvec_y(momdp, n_y, uniform_sparse)
+            
+            @test length(b_vec_uniform) == n_y
+            @test all(b_vec_uniform .≈ 1.0/n_y)
+            @test sum(b_vec_uniform) ≈ 1.0
+            
+            # Test with single state sparse belief
+            single_sparse = SparseCat([states_y_list[1]], [1.0])
+            b_vec_single = MOMDPs.beliefvec_y(momdp, n_y, single_sparse)
+            
+            @test b_vec_single[1] ≈ 1.0
+            @test all(b_vec_single[2:end] .≈ 0.0)
+        end
+    end
+    
+    @testset "actionvalues Tests" begin
+        _, momdp, _ = create_test_rocksample()
+        
+        # Create a simple alpha vector policy for testing
+        n_x = length(states_x(momdp))
+        n_y = length(states_y(momdp))
+        n_actions = length(actions(momdp))
+        
+        # Create simple alphas with different values for different actions
+        alphas = Vector{Vector{Vector{Float64}}}(undef, n_x)
+        action_map = Vector{Vector{Int}}(undef, n_x)
+        
+        for x_idx in 1:n_x
+            # Create multiple alpha vectors for different actions
+            n_alphas = min(3, n_actions)  # Limit for testing
+            alphas[x_idx] = Vector{Vector{Float64}}(undef, n_alphas)
+            action_map[x_idx] = Vector{Int}(undef, n_alphas)
+            
+            for alpha_idx in 1:n_alphas
+                alphas[x_idx][alpha_idx] = zeros(n_y)
+                action_map[x_idx][alpha_idx] = alpha_idx
+                
+                # Create different value patterns for different actions
+                for y_idx in 1:n_y
+                    alphas[x_idx][alpha_idx][y_idx] = alpha_idx * (n_y - y_idx + 1)
+                end
+            end
+        end
+        
+        policy = MOMDPAlphaVectorPolicy(momdp, n_x, n_y, alphas, action_map)
+        
+        @testset "Basic actionvalues Computation" begin
+            # Test with uniform belief over hidden states
+            b_uniform = uniform_belief_y(momdp)
+            x = first(states_x(momdp))
+            
+            qa = MOMDPs.actionvalues(policy, b_uniform, x)
+            
+            @test isa(qa, Vector{Float64})
+            @test length(qa) == n_actions
+            @test all(isfinite.(qa))  # All values should be finite
+            
+            # Action values should be real numbers (can be negative due to step penalties)
+            @test all(isa(q, Real) for q in qa)
+        end
+        
+        @testset "Different Beliefs" begin
+            x = first(states_x(momdp))
+            
+            # Test with deterministic belief
+            det_state = first(ordered_states_y(momdp))
+            b_det = SparseCat([det_state], [1.0])
+            qa_det = MOMDPs.actionvalues(policy, b_det, x)
+            
+            @test length(qa_det) == n_actions
+            @test all(isfinite.(qa_det))
+            
+            # Test with structured belief
+            states_y_list = ordered_states_y(momdp)
+            structured_probs = [0.5, 0.3, 0.2, 0.0, 0.0, 0.0, 0.0, 0.0]
+            b_structured = DiscreteBelief(momdp, states_y_list, structured_probs)
+            qa_structured = MOMDPs.actionvalues(policy, b_structured, x)
+            
+            @test length(qa_structured) == n_actions
+            @test all(isfinite.(qa_structured))
+        end
+        
+        @testset "Different Visible States" begin
+            b = uniform_belief_y(momdp)
+            states_x_list = collect(states_x(momdp))
+            
+            # Test with different visible states
+            x1 = states_x_list[1]
+            x2 = states_x_list[min(2, length(states_x_list))]
+            
+            qa1 = MOMDPs.actionvalues(policy, b, x1)
+            qa2 = MOMDPs.actionvalues(policy, b, x2)
+            
+            @test length(qa1) == n_actions
+            @test length(qa2) == n_actions
+            @test all(isfinite.(qa1))
+            @test all(isfinite.(qa2))
+        end
+    end
+    
     @testset "File I/O Tests" begin
         MOMDPs.is_y_prime_dependent_on_x_prime(::RockSampleMOMDP) = false
         MOMDPs.is_x_prime_dependent_on_y(::RockSampleMOMDP) = false


### PR DESCRIPTION
- Fixed some syntax with extension of functions from POMDPTools. 
- Added `MOMDPDiscreteUpdater` to help with beliefs over just the hidden states.
- Added `action` and `actionvalues` functions that take the visible state as an input.